### PR TITLE
First crack at it, modules, docker, backspace support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:22.04 as base
+
+#base update upgrade 
+RUN apt update -y 
+RUN apt upgrade -y 
+
+#system utils 
+RUN apt install -y curl \
+    gpg \
+    openssh-server \
+    git \
+    python3-dev \
+    python3-pip \
+    sudo \
+    vim 
+ 
+#client ssh stuffs
+RUN apt-get -y install openssh-client
+RUN ssh-keygen -q -t rsa -N '' -f /id_rsa
+
+RUN useradd -rm -d /home/neo -s /bin/bash -G sudo -u 1000 neo
+RUN chown -R neo: /opt
+USER neo
+WORKDIR /opt
+RUN git clone https://github.com/ice-wzl/FFM.git
+RUN cd FFM/
+RUN pip3 install tqdm
+RUN export PATH=$PATH:/home/neo/.local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN useradd -rm -d /home/neo -s /bin/bash -G sudo -u 1000 neo
 RUN chown -R neo: /opt
 USER neo
 WORKDIR /opt
-RUN git clone https://github.com/ice-wzl/FFM.git
+RUN https://github.com/JusticeRage/FFM.git
 RUN cd FFM/
 RUN pip3 install tqdm
 RUN export PATH=$PATH:/home/neo/.local/bin

--- a/commands/remote_script.py
+++ b/commands/remote_script.py
@@ -88,7 +88,8 @@ class RunPyScript(RemoteScript):
 
     def _get_interpreter(self):
         return "python"
-
+    
+        
     def _get_command_line(self):
         return "{interpreter} - {args} <<'__EOF__'\r\n{script}\r\n__EOF__"
 
@@ -98,6 +99,35 @@ class RunPyScript(RemoteScript):
 
 # -----------------------------------------------------------------------------
 
+class RunPy3Script(RemoteScript):
+    @staticmethod
+    def regexp():
+        return r"^\s*\!py3($| )"
+
+    @staticmethod
+    def usage():
+        write_str("Usage: !py3 [script on the local machine] [script arguments]\r\n", LogLevel.WARNING)
+
+    @staticmethod
+    def name():
+        return "!py3"
+
+    @staticmethod
+    def description():
+        return "Runs a python3 script from the local machine in memory."
+
+    def _get_interpreter(self):
+        return "python3"
+    
+        
+    def _get_command_line(self):
+        return "{interpreter} - {args} <<'__EOF__'\r\n{script}\r\n__EOF__"
+
+    def _get_output_cleaner(self):
+        # The Python interpreter displays a prompt while reading scripts from stdin. Strip it.
+        return lambda s: s.lstrip(" >")
+
+# -----------------------------------------------------------------------------
 class RunShScript(RemoteScript):
     @staticmethod
     def regexp():
@@ -124,4 +154,5 @@ class RunShScript(RemoteScript):
 # -----------------------------------------------------------------------------
 
 register_plugin(RunPyScript)
+register_plugin(RunPy3Script)
 register_plugin(RunShScript)

--- a/commands/replacement_commands.py
+++ b/commands/replacement_commands.py
@@ -103,6 +103,8 @@ class Debug(Command):
         write_str("Current command prompt: %s\r\n" %
                   context.active_session.input_driver.last_line.encode("UTF-8"), LogLevel.WARNING)
 
+# -----------------------------------------------------------------------------
+
 class Suid(Command):
     def __init__(self, *args, **kwargs):
         pass
@@ -127,8 +129,35 @@ class Suid(Command):
         write_str("SUID + SGID Binaries: \r\n", LogLevel.WARNING)
         shell_exec("find / -perm -4000 -type f ! -path '/dev/*' -exec ls -la {} \; 2>/dev/null; find / -perm -4000 -type f ! -path '/dev/*' -exec ls -la {} \; 2>/dev/null", print_output=True)
 
+#lsmem | grep '^Total online memory:' | tr -s " " && lscpu | grep "^Architecture" | tr -s " " && lscpu | grep "^CPU(s)" | tr -s " " && echo "Kernel Version: $(uname -r)"
+
+class Info(Command):
+    def __init__(self, *args, **kwargs):
+        pass
+
+    @staticmethod
+    def regexp():
+        return r"^\s*\!info($| )"
+
+    @staticmethod
+    def name():
+        return "!info"
+
+    @staticmethod
+    def description():
+        return "Returns CPU(s), Architecture, Memory, and Kernel Verison for the current machine."
+
+    @staticmethod
+    def usage():
+        return "Usage: !info"
+
+    def execute(self):
+        write_str("System Info: \r\n", LogLevel.WARNING)
+        shell_exec('lscpu | grep "^CPU(s)" | tr -s " " && lscpu | grep "^Architecture" | tr -s " " && echo "Kernel Version: $(uname -r)" && lsmem | grep "^Total online memory:" | tr -s " "', print_output=True)
+
 
 register_plugin(GetOS)
 register_plugin(PtySpawn)
 register_plugin(Debug)
 register_plugin(Suid)
+register_plugin(Info)

--- a/commands/replacement_commands.py
+++ b/commands/replacement_commands.py
@@ -1,5 +1,5 @@
 """
-    ffm.py by @JusticeRage
+    ffm.py by @JusticeRage and @ice-wzl
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -129,8 +129,6 @@ class Suid(Command):
         write_str("SUID + SGID Binaries: \r\n", LogLevel.WARNING)
         shell_exec("find / -perm -4000 -type f ! -path '/dev/*' -exec ls -la {} \; 2>/dev/null; find / -perm -4000 -type f ! -path '/dev/*' -exec ls -la {} \; 2>/dev/null", print_output=True)
 
-#lsmem | grep '^Total online memory:' | tr -s " " && lscpu | grep "^Architecture" | tr -s " " && lscpu | grep "^CPU(s)" | tr -s " " && echo "Kernel Version: $(uname -r)"
-
 class Info(Command):
     def __init__(self, *args, **kwargs):
         pass
@@ -154,6 +152,8 @@ class Info(Command):
     def execute(self):
         write_str("System Info: \r\n", LogLevel.WARNING)
         shell_exec('lscpu | grep "^CPU(s)" | tr -s " " && lscpu | grep "^Architecture" | tr -s " " && echo "Kernel Version: $(uname -r)" && lsmem | grep "^Total online memory:" | tr -s " "', print_output=True)
+
+# -----------------------------------------------------------------------------
 
 
 register_plugin(GetOS)

--- a/commands/replacement_commands.py
+++ b/commands/replacement_commands.py
@@ -103,7 +103,32 @@ class Debug(Command):
         write_str("Current command prompt: %s\r\n" %
                   context.active_session.input_driver.last_line.encode("UTF-8"), LogLevel.WARNING)
 
+class Suid(Command):
+    def __init__(self, *args, **kwargs):
+        pass
+
+    @staticmethod
+    def regexp():
+        return r"^\s*\!suid($| )"
+
+    @staticmethod
+    def name():
+        return "!suid"
+
+    @staticmethod
+    def description():
+        return "Finds SUID, SGID binaries on the current machine."
+
+    @staticmethod
+    def usage():
+        return "Usage: !suid"
+
+    def execute(self):
+        write_str("SUID + SGID Binaries: \r\n", LogLevel.WARNING)
+        shell_exec("find / -perm -4000 -type f ! -path '/dev/*' -exec ls -la {} \; 2>/dev/null; find / -perm -4000 -type f ! -path '/dev/*' -exec ls -la {} \; 2>/dev/null", print_output=True)
+
 
 register_plugin(GetOS)
 register_plugin(PtySpawn)
 register_plugin(Debug)
+register_plugin(Suid)

--- a/ffm.conf
+++ b/ffm.conf
@@ -35,6 +35,9 @@ prevent_ssh_key_leaks = yes
 # If true, SSH will not log the remote server's public key in the known_hosts file.
 disable_known_hosts = yes
 
+# If false, SSH will not conduct strict host checking to see if remote host fingerprint has changed
+strict_host_checking = no
+
 [RdesktopOptions]
 # If this is true, the harness will reject rdesktop commands that don't contain an explicit username,
 # i.e. rdesktop -u Administrator. This prevents you from leaking your username if none is specified.

--- a/ffm.conf
+++ b/ffm.conf
@@ -36,7 +36,7 @@ prevent_ssh_key_leaks = yes
 disable_known_hosts = yes
 
 # If false, SSH will not conduct strict host checking to see if remote host fingerprint has changed
-strict_host_checking = no
+strict_host_key_checking = no
 
 [RdesktopOptions]
 # If this is true, the harness will reject rdesktop commands that don't contain an explicit username,

--- a/model/driver/input.py
+++ b/model/driver/input.py
@@ -616,7 +616,7 @@ class DefaultInputDriver(BaseDriver):
         elif c == 0x17:
             self.delete_word()
         # Backspace (^H)
-        elif c == 0x7F:
+        elif c == 0x7F or c == 0x08:
             self.backspace()
         elif 0 <= c <= 0x17 or c == 0x19 or 0x1C <= c <= 0x1F:
             # Execute

--- a/model/session.py
+++ b/model/session.py
@@ -26,7 +26,8 @@ from model.driver import input, output
 class Session:
     def __init__(self):
         self.master, self.slave = pty.openpty()
-        self.bash = subprocess.Popen([os.getenv("SHELL", "/bin/bash")],
+        #self.bash = subprocess.Popen([os.getenv("SHELL", "/bin/bash")],
+        self.bash = subprocess.Popen([os.getenv("SHELL", "/bin/sh")],
                                      preexec_fn=os.setsid,
                                      stdin=self.slave,
                                      stdout=self.slave,

--- a/model/session.py
+++ b/model/session.py
@@ -26,8 +26,10 @@ from model.driver import input, output
 class Session:
     def __init__(self):
         self.master, self.slave = pty.openpty()
-        #self.bash = subprocess.Popen([os.getenv("SHELL", "/bin/bash")],
-        self.bash = subprocess.Popen([os.getenv("SHELL", "/bin/sh")],
+        #I am unsure here, still tweaking things, leaving the /bin/sh line here for ease of testing.
+        #Need to write some unit tests for this
+        #self.bash = subprocess.Popen([os.getenv("SHELL", "/bin/sh")],
+        self.bash = subprocess.Popen([os.getenv("SHELL", "/bin/bash")],
                                      preexec_fn=os.setsid,
                                      stdin=self.slave,
                                      stdout=self.slave,

--- a/processors/ssh_command_line.py
+++ b/processors/ssh_command_line.py
@@ -1,5 +1,5 @@
 """
-    FFM by @JusticeRage
+    FFM by @JusticeRage and @ice-wzl
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/processors/ssh_command_line.py
+++ b/processors/ssh_command_line.py
@@ -80,6 +80,10 @@ class SSHOptions(Processor):
             if not args.T:
                 options_added.append("-T")
 
+        if context.config["SSHOptions"]["strict_host_checking"]:
+            if not args.o or not any("StrictHostChecking" in option for option in args.o):
+                options_added.append("-oStrictHostChecking=no")
+
         if options_added:
             user_input = user_input.replace(ssh_cmdline, "%s %s" % (ssh_cmdline, " ".join(options_added)), 1)
             write_str("Notice: the following options were added to the SSH command: %s.\r\n" % ", ".join(options_added),

--- a/processors/ssh_command_line.py
+++ b/processors/ssh_command_line.py
@@ -80,9 +80,9 @@ class SSHOptions(Processor):
             if not args.T:
                 options_added.append("-T")
 
-        if context.config["SSHOptions"]["strict_host_checking"]:
-            if not args.o or not any("StrictHostChecking" in option for option in args.o):
-                options_added.append("-oStrictHostChecking=no")
+        if context.config["SSHOptions"]["strict_host_key_checking"]:
+            if not args.o or not any("StrictHostKeyChecking" in option for option in args.o):
+                options_added.append("-oStrictHostKeyChecking=no")
 
         if options_added:
             user_input = user_input.replace(ssh_cmdline, "%s %s" % (ssh_cmdline, " ".join(options_added)), 1)


### PR DESCRIPTION
## Additional Modules 
- Pretty straight forward, added a `!info` module to see basic computer stats, and a `!suid` module to quickly find SUID and SGID binaries.
- Added option in `ffm.conf` to allow `StrictHostKeyChecking` to be set to no....or yes depending on what the user wants.
- Not having this option in some of my ssh lines was causing some issues
- Stole your `RunPyScript` class and just copied it below to also include `python3` so `!py` will get the python2.X scripts into memory and the `!py3` command will get the python3.X scripts into memory.
## Backspace command support
- Added support for `0x08` backspace command. This being absent was causing a whole host of issues for me on ubuntu 22.04 but it appears to be resolved now. I imagine machines using `0x08` wasnt implemented when this was originally written...but I have no idea.
## Design Choice
- Added a Dockerfile (its perfect by no means, but will continue to tweak it) to get a consistent environment that I can control consistently and then work out the issues introduced by different systems having different shells prompts etc etc 
- Having it run out of a container appeared to solve a ton of errors I was running into just by having a nice clean ubuntu 22.04 container that can be added onto over time.
- IMO best case it gives users across the board who use a variety of systems a consistent platform, worst case its not used and they opt to install it directly which doesnt hurt to still have the option.

- Pretty cool and unique repo, Id love to keep working on it you really set up a solid foundation to work from. Theres alot of potential here.  Feel free to edit this PR as you wish.